### PR TITLE
More fixes for settings and disable by default

### DIFF
--- a/LSP-Deno.sublime-settings
+++ b/LSP-Deno.sublime-settings
@@ -1,69 +1,47 @@
 {
-    "initializationOptions": {
-        "enable": true,
-        "lint": true,
-        "unstable": false
-    },
+    "enabled": false,
     "selector": "source.ts.react | source.tsx | source.ts | source.js.react | source.jsx | source.js",
-    "command": [
-        "deno",
-        "lsp"
-    ],
+    "command": ["deno", "lsp"],
     "settings": {
-        // Enables or disables the display of code lens information for implementations of items in
-        // the code.
+        // Enables or disables the display of code lens information for implementations of items in the code.
         "deno.codeLens.implementations": false,
-        // Enables or disables the display of code lens information for references of items in the
-        // code.
+        // Enables or disables the display of code lens information for references of items in the code.
         "deno.codeLens.references": false,
         // Enables or disables the display of code lens information for all functions in the code.
         "deno.codeLens.referencesAllFunctions": false,
-        // Enables or disables the display of code lenses that allow running of individual tests in
-        // the code.
+        // Enables or disables the display of code lenses that allow running of individual tests in the code.
         "deno.codeLens.test": true,
-        // Additional arguments to use with the run test code lens.  Defaults to `[ "--allow-all"
-        // ]`.
+        // Additional arguments to use with the run test code lens.  Defaults to `[ "--allow-all" ]`.
         "deno.codeLens.testArgs": [
             "--allow-all"
         ],
         // The file path to a `tsconfig.json` file. This is the equivalent to using `--config` on
-        // the command line. The path can be either be relative to the workspace, or an absolute
-        // path.
-        // **Not recommended to be set globally.**
+        // the command line. The path can be either be relative to the workspace, or an absolute path.
+        // **Recommended to be set per-project.**
         "deno.config": null,
         // Controls if the Deno Language Server is enabled. When enabled, the extension will disable
         // the built-in VSCode JavaScript and TypeScript language services, and will use the Deno
         // Language Server (`deno lsp`) instead.
-        // **Not recommended to be enabled globally.**
-        "deno.enable": false,
-        // The file path to an import map. This is the equivalent to using `--import-map` on the
-        // command line.
+        "deno.enable": true,
+        // The file path to an import map. This is the equivalent to using `--import-map` on the command line.
         // [Import maps](https://deno.land/manual@v1.6.0/linking_to_external_code/import_maps)
         // provide a way to "relocate" modules based on their specifiers. The path can either be
         // relative to the workspace, or an absolute path.
-        // **Not recommended to be set globally.**
+        // **Recommended to be set per-project.**
         "deno.importMap": null,
         // Determines if the internal debugging information for the Deno language server will be
         // logged to the _Deno Language Server_ console.
         "deno.internalDebug": false,
         // Controls if linting information will be provided by the Deno Language Server.
-        // **Not recommended to be enabled globally.**
-        "deno.lint": false,
-        // A path to the `deno` CLI executable. By default, the extension looks for `deno` in the
-        // `PATH`, but if set, will use the path specified instead.
-        "deno.path": null,
-        // unknown setting
+        "deno.lint": true,
         "deno.suggest.autoImports": true,
-        // unknown setting
         "deno.suggest.completeFunctionCalls": false,
         // If enabled, when new hosts/origins are encountered that support import suggestions, you
         // will be prompted to enable or disable it.  Defaults to `true`.
         "deno.suggest.imports.autoDiscover": true,
         // Controls which hosts are enabled for import suggestions.
         "deno.suggest.imports.hosts": {},
-        // unknown setting
         "deno.suggest.names": true,
-        // unknown setting
         "deno.suggest.paths": true,
         // Controls if code will be type checked with Deno's unstable APIs. This is the equivalent
         // to using `--unstable` on the command line.

--- a/README.md
+++ b/README.md
@@ -20,4 +20,6 @@ The Deno language server operates on the following base scopes:
 
 # Configuration
 
-You may edit the default settings by running _Preferences: LSP-Deno Settings_ from the _Command Palette_.
+The server **does not automatically start** for the scopes listed above - it's expected that you enable it for a given project by running `LSP: Enable Language Server in Project` from the _Command Palette_.
+
+You may edit the default settings by running `Preferences: LSP-Deno Settings` from the _Command Palette_.

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -70,8 +70,11 @@
                         "/path/to/tsconfig.json",
                         "C:\\path\\to\\tsconfig.json"
                       ],
-                      "markdownDescription": "The file path to a `tsconfig.json` file. This is the equivalent to using `--config` on the command line. The path can be either be relative to the workspace, or an absolute path.\n\n**Not recommended to be set globally.**",
-                      "type": "string"
+                      "markdownDescription": "The file path to a `tsconfig.json` file. This is the equivalent to using `--config` on the command line. The path can be either be relative to the workspace, or an absolute path.\n\n**Recommended to be set per-project.**",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "deno.enable": {
                       "default": false,
@@ -79,7 +82,7 @@
                         true,
                         false
                       ],
-                      "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server (`deno lsp`) instead.\n\n**Not recommended to be enabled globally.**",
+                      "markdownDescription": "Controls if the Deno Language Server is enabled. When enabled, the extension will disable the built-in VSCode JavaScript and TypeScript language services, and will use the Deno Language Server (`deno lsp`) instead.",
                       "type": "boolean"
                     },
                     "deno.importMap": {
@@ -89,8 +92,11 @@
                         "/path/to/import_map.json",
                         "C:\\path\\to\\import_map.json"
                       ],
-                      "markdownDescription": "The file path to an import map. This is the equivalent to using `--import-map` on the command line.\n\n[Import maps](https://deno.land/manual@v1.6.0/linking_to_external_code/import_maps) provide a way to \"relocate\" modules based on their specifiers. The path can either be relative to the workspace, or an absolute path.\n\n**Not recommended to be set globally.**",
-                      "type": "string"
+                      "markdownDescription": "The file path to an import map. This is the equivalent to using `--import-map` on the command line.\n\n[Import maps](https://deno.land/manual@v1.6.0/linking_to_external_code/import_maps) provide a way to \"relocate\" modules based on their specifiers. The path can either be relative to the workspace, or an absolute path.\n\n**Recommended to be set per-project.**",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "deno.internalDebug": {
                       "default": false,
@@ -107,17 +113,8 @@
                         true,
                         false
                       ],
-                      "markdownDescription": "Controls if linting information will be provided by the Deno Language Server.\n\n**Not recommended to be enabled globally.**",
+                      "markdownDescription": "Controls if linting information will be provided by the Deno Language Server.",
                       "type": "boolean"
-                    },
-                    "deno.path": {
-                      "default": null,
-                      "examples": [
-                        "/usr/bin/deno",
-                        "C:\\Program Files\\deno\\deno.exe"
-                      ],
-                      "markdownDescription": "A path to the `deno` CLI executable. By default, the extension looks for `deno` in the `PATH`, but if set, will use the path specified instead.",
-                      "type": "string"
                     },
                     "deno.suggest.autoImports": {
                       "default": true,
@@ -134,9 +131,11 @@
                     },
                     "deno.suggest.imports.hosts": {
                       "default": {},
-                      "examples": {
-                        "https://deno.land/": true
-                      },
+                      "examples": [
+                        {
+                          "https://deno.land/": true
+                        }
+                      ],
                       "markdownDescription": "Controls which hosts are enabled for import suggestions.",
                       "type": "object"
                     },


### PR DESCRIPTION
It doesn't seem to be necessary to specify options in initializationOptions
as the server will also request them per-file. And the server really
expects the same options (bar the "deno." prefix) in both cases so it
wasn't a complete solution anyway.

Also set "enabled": false by default with the intention of user enabling
it per-project. Given that the `deno.enable` and `deno.lint` are now by
default enabled.

And fixup some settings:
 - allow "null" value for some that had that value
 - rephrase "Not recommended to be set globally" since it has a bit
   different meaning in our case
 - remove "deno.path" which was an VS extension setting and in our case
   the "command" handles that
 - fixup invalid `examples` for the `hosts` setting

Fixes #4